### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
       <option value="Bhutan" data-alternative-spellings="BT भूटान">Bhutan</option>
       <option value="Bolivia" data-alternative-spellings="BO">Bolivia</option>
       <option value="Bonaire, Sint Eustatius and Saba" data-alternative-spellings="BQ">Bonaire, Sint Eustatius and Saba</option>
-      <option value="Bosnia and Herzegovina" data-alternative-spellings="BA Босна и Херцеговина">Bosnia and Herzegovina</option>
+      <option value="Bosnia and Herzegovina" data-alternative-spellings="BA BiH Bosna i Hercegovina Босна и Херцеговина">Bosnia and Herzegovina</option>
       <option value="Botswana" data-alternative-spellings="BW">Botswana</option>
       <option value="Bouvet Island" data-alternative-spellings="BV">Bouvet Island</option>
       <option value="Brazil" data-alternative-spellings="BR Brasil" data-relevancy-booster="2">Brazil</option>


### PR DESCRIPTION
Add three-letter code for Bosnia and Herzegovina according to
ISO 3166-1 (see http://en.wikipedia.org/wiki/ISO_3166-1 and
http://en.wikipedia.org/wiki/List_of_international_vehicle_registration_codes)
and Latin spelling of local name in addition to Cyrillic.
