### PR TITLE
select filtered option on exit

### DIFF
--- a/jquery.select-to-autocomplete.js
+++ b/jquery.select-to-autocomplete.js
@@ -25,7 +25,7 @@ THE SOFTWARE.
 */
 (function($){
   var settings = {
-    'select-filtered-option-on-blur': false,
+    'select-filtered-option-on-exit': false,
     'sort': false,
     'sort-attr': 'data-priority',
     'sort-desc': false,
@@ -47,7 +47,7 @@ THE SOFTWARE.
       if ( context.settings['remove-valueless-options'] ) {
         selected_finder = 'option:selected[value!=""]:first';
       }
-      if (context.settings['select-filtered-option-on-blur'] && context.filtered_options) {
+      if (context.settings['select-filtered-option-on-exit'] && context.filtered_options) {
           // select the first option in filtered_options
           context.$text_field.val(context.filtered_options[0].label);
       }

--- a/jquery.select-to-autocomplete.js
+++ b/jquery.select-to-autocomplete.js
@@ -25,6 +25,7 @@ THE SOFTWARE.
 */
 (function($){
   var settings = {
+    'select-filtered-option-on-blur': false,
     'sort': false,
     'sort-attr': 'data-priority',
     'sort-desc': false,
@@ -46,7 +47,13 @@ THE SOFTWARE.
       if ( context.settings['remove-valueless-options'] ) {
         selected_finder = 'option:selected[value!=""]:first';
       }
-      context.$text_field.val( context.$select_field.find( selected_finder ).text() );
+      if (context.settings['select-filtered-option-on-blur'] && context.filtered_options) {
+          // select the first option in filtered_options
+          context.$text_field.val(context.filtered_options[0].label);
+      }
+      else {
+      	  context.$text_field.val( context.$select_field.find( selected_finder ).text() );
+      }
     },
     handle_select_field: function( $select_field ) {
       return $select_field.hide();
@@ -259,9 +266,9 @@ THE SOFTWARE.
         'delay': context.settings['delay'],
         'autoFocus': context.settings['autoFocus'],
         source: function( request, response ) {
-          var filtered_options = filter_options( request.term );
+          context.filtered_options = filter_options( request.term );
           if ( context.settings['relevancy-sorting'] ) {
-            filtered_options = filtered_options.sort( function( a, b ) { 
+            context.filtered_options = context.filtered_options.sort( function( a, b ) { 
             	if (b['relevancy-score'] == a['relevancy-score']) {
             		return b['label'] < a['label'] ? 1 : -1;	
             	} else {
@@ -269,7 +276,7 @@ THE SOFTWARE.
             	}
             } );
           }
-          response( filtered_options );
+          response( context.filtered_options );
         },
         select: function( event, ui ) {
           update_select_value( ui.item );


### PR DESCRIPTION
Added new functionality that selects the first option when the cursor leaves the input.
The functionality is enabled and disabled with the new setting 'select-filtered-option-on-blur'. The setting's default value is false so the default behavior on the plugin is unchanged.
