### PR TITLE
Added and fixed some alternative spellings

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,11 +102,11 @@
       <option value="Cocos (Keeling) Islands" data-alternative-spellings="CC" data-relevancy-booster="0.5">Cocos (Keeling) Islands</option>
       <option value="Colombia" data-alternative-spellings="CO">Colombia</option>
       <option value="Comoros" data-alternative-spellings="KM جزر القمر">Comoros</option>
-      <option value="Congo" data-alternative-spellings="CG">Congo</option>
-      <option value="Congo, the Democratic Republic of the" data-alternative-spellings="CD Congo-Brazzaville Repubilika ya Kongo">Congo, the Democratic Republic of the</option>
+      <option value="Congo" data-alternative-spellings="CG Congo-Brazzaville">Congo</option>
+      <option value="Congo, the Democratic Republic of the" data-alternative-spellings="CD Congo-Kinshasa Repubilika ya Kongo">Congo, the Democratic Republic of the</option>
       <option value="Cook Islands" data-alternative-spellings="CK" data-relevancy-booster="0.5">Cook Islands</option>
       <option value="Costa Rica" data-alternative-spellings="CR">Costa Rica</option>
-      <option value="Côte d'Ivoire" data-alternative-spellings="CI Cote dIvoire">Côte d'Ivoire</option>
+      <option value="Côte d'Ivoire" data-alternative-spellings="CI Cote dIvoire Ivory Coast">Côte d'Ivoire</option>
       <option value="Croatia" data-alternative-spellings="HR Hrvatska">Croatia</option>
       <option value="Cuba" data-alternative-spellings="CU">Cuba</option>
       <option value="Curaçao" data-alternative-spellings="CW Curacao">Curaçao</option>
@@ -173,7 +173,7 @@
       <option value="Korea, Republic of" data-alternative-spellings="KR South Korea" data-relevancy-booster="1.5">Korea, Republic of</option>
       <option value="Kuwait" data-alternative-spellings="KW الكويت">Kuwait</option>
       <option value="Kyrgyzstan" data-alternative-spellings="KG Кыргызстан">Kyrgyzstan</option>
-      <option value="Lao People's Democratic Republic" data-alternative-spellings="LA">Lao People's Democratic Republic</option>
+      <option value="Lao People's Democratic Republic" data-alternative-spellings="LA Laos">Lao People's Democratic Republic</option>
       <option value="Latvia" data-alternative-spellings="LV Latvija">Latvia</option>
       <option value="Lebanon" data-alternative-spellings="LB لبنان">Lebanon</option>
       <option value="Lesotho" data-alternative-spellings="LS">Lesotho</option>
@@ -273,7 +273,7 @@
       <option value="Tajikistan" data-alternative-spellings="TJ Тоҷикистон Toçikiston">Tajikistan</option>
       <option value="Tanzania, United Republic of" data-alternative-spellings="TZ">Tanzania, United Republic of</option>
       <option value="Thailand" data-alternative-spellings="TH ประเทศไทย Prathet Thai">Thailand</option>
-      <option value="Timor-Leste" data-alternative-spellings="TL">Timor-Leste</option>
+      <option value="Timor-Leste" data-alternative-spellings="TL East Timor">Timor-Leste</option>
       <option value="Togo" data-alternative-spellings="TG Togolese">Togo</option>
       <option value="Tokelau" data-alternative-spellings="TK" data-relevancy-booster="0.5">Tokelau</option>
       <option value="Tonga" data-alternative-spellings="TO">Tonga</option>


### PR DESCRIPTION
Notably fixing alternative spellings for Congo and DRC.
Adding new alternative spellings for Cote D'Ivoire, Timor-Leste, Laos.
